### PR TITLE
enable webgui

### DIFF
--- a/datapower/src/drouter/config/auto-startup.cfg
+++ b/datapower/src/drouter/config/auto-startup.cfg
@@ -634,7 +634,7 @@ save-config overwrite
 %endif%
 
 web-mgmt
-  admin-state "disabled"
+  admin-state "enabled"
   local-address "0.0.0.0" "9090"
   save-config-overwrite 
   idle-timeout 600


### PR DESCRIPTION
This is needed to enable the webgui management port.  
Remaining, modify docker-compose to expose 9090..