### PR TITLE
Enable datapower web-admin and expose at https://gwadmin/

### DIFF
--- a/datapower/src/drouter/config/auto-startup.cfg
+++ b/datapower/src/drouter/config/auto-startup.cfg
@@ -634,7 +634,7 @@ save-config overwrite
 %endif%
 
 web-mgmt
-  admin-state "disabled"
+  admin-state "enabled"
   local-address "0.0.0.0" "9090"
   save-config-overwrite 
   idle-timeout 600

--- a/sni-proxy/nginx.tmpl
+++ b/sni-proxy/nginx.tmpl
@@ -11,6 +11,7 @@ stream {
         PORTAL  portal_backend;
         APIM    apim_backend;
         GATEWAY gateway_backend;
+        GWADMIN gateway_admin;
         default gateway_backend;
     }
 
@@ -24,6 +25,9 @@ stream {
 
     upstream gateway_backend {
         server GATEWAY:443;
+    }
+    upstream gateway_admin {
+        server GATEWAY:9090;
     }
 
     server {


### PR DESCRIPTION
Enable the datapower admin console and expose it through the nginx reverse proxy